### PR TITLE
Fix breadcrumb links for USA service pages

### DIFF
--- a/scripts/generate_state_pages.py
+++ b/scripts/generate_state_pages.py
@@ -83,7 +83,7 @@ TEMPLATE = Template("""<!DOCTYPE html>
     <ul class=\"breadcrumb\">
       <li><a href=\"/\">Home</a></li>
       <li><a href=\"/service-areas/\">Service Areas</a></li>
-      <li><a href=\"/service-areas/north-america/usa\">United States</a></li>
+      <li><a href=\"/service-areas/usa\">United States</a></li>
       <li>$state</li>
     </ul>
   </nav>

--- a/service-areas/new-jersey/index.html
+++ b/service-areas/new-jersey/index.html
@@ -78,7 +78,7 @@
     <ul class="breadcrumb">
       <li><a href="/">Home</a></li>
       <li><a href="/service-areas/">Service Areas</a></li>
-      <li><a href="/service-areas/north-america/usa">United States</a></li>
+      <li><a href="/service-areas/usa">United States</a></li>
       <li>New Jersey</li>
     </ul>
   </nav>

--- a/service-areas/rhode-island/index.html
+++ b/service-areas/rhode-island/index.html
@@ -78,7 +78,7 @@
     <ul class="breadcrumb">
       <li><a href="/">Home</a></li>
       <li><a href="/service-areas/">Service Areas</a></li>
-      <li><a href="/service-areas/north-america/usa">United States</a></li>
+      <li><a href="/service-areas/usa">United States</a></li>
       <li>Rhode Island</li>
     </ul>
   </nav>

--- a/service-areas/usa/alabama/index.html
+++ b/service-areas/usa/alabama/index.html
@@ -78,7 +78,7 @@
     <ul class="breadcrumb">
       <li><a href="/">Home</a></li>
       <li><a href="/service-areas/">Service Areas</a></li>
-      <li><a href="/service-areas/north-america/usa">United States</a></li>
+      <li><a href="/service-areas/usa">United States</a></li>
       <li>Alabama</li>
     </ul>
   </nav>

--- a/service-areas/usa/arizona/index.html
+++ b/service-areas/usa/arizona/index.html
@@ -78,7 +78,7 @@
     <ul class="breadcrumb">
       <li><a href="/">Home</a></li>
       <li><a href="/service-areas/">Service Areas</a></li>
-      <li><a href="/service-areas/north-america/usa">United States</a></li>
+      <li><a href="/service-areas/usa">United States</a></li>
       <li>Arizona</li>
     </ul>
   </nav>

--- a/service-areas/usa/colorado/index.html
+++ b/service-areas/usa/colorado/index.html
@@ -78,7 +78,7 @@
     <ul class="breadcrumb">
       <li><a href="/">Home</a></li>
       <li><a href="/service-areas/">Service Areas</a></li>
-      <li><a href="/service-areas/north-america/usa">United States</a></li>
+      <li><a href="/service-areas/usa">United States</a></li>
       <li>Colorado</li>
     </ul>
   </nav>

--- a/service-areas/usa/connecticut/index.html
+++ b/service-areas/usa/connecticut/index.html
@@ -78,7 +78,7 @@
     <ul class="breadcrumb">
       <li><a href="/">Home</a></li>
       <li><a href="/service-areas/">Service Areas</a></li>
-      <li><a href="/service-areas/north-america/usa">United States</a></li>
+      <li><a href="/service-areas/usa">United States</a></li>
       <li>Connecticut</li>
     </ul>
   </nav>

--- a/service-areas/usa/florida/index.html
+++ b/service-areas/usa/florida/index.html
@@ -78,7 +78,7 @@
     <ul class="breadcrumb">
       <li><a href="/">Home</a></li>
       <li><a href="/service-areas/">Service Areas</a></li>
-      <li><a href="/service-areas/north-america/usa">United States</a></li>
+      <li><a href="/service-areas/usa">United States</a></li>
       <li>Florida</li>
     </ul>
   </nav>

--- a/service-areas/usa/georgia/index.html
+++ b/service-areas/usa/georgia/index.html
@@ -78,7 +78,7 @@
     <ul class="breadcrumb">
       <li><a href="/">Home</a></li>
       <li><a href="/service-areas/">Service Areas</a></li>
-      <li><a href="/service-areas/north-america/usa">United States</a></li>
+      <li><a href="/service-areas/usa">United States</a></li>
       <li>Georgia</li>
     </ul>
   </nav>

--- a/service-areas/usa/illinois/index.html
+++ b/service-areas/usa/illinois/index.html
@@ -78,7 +78,7 @@
     <ul class="breadcrumb">
       <li><a href="/">Home</a></li>
       <li><a href="/service-areas/">Service Areas</a></li>
-      <li><a href="/service-areas/north-america/usa">United States</a></li>
+      <li><a href="/service-areas/usa">United States</a></li>
       <li>Illinois</li>
     </ul>
   </nav>

--- a/service-areas/usa/indiana/index.html
+++ b/service-areas/usa/indiana/index.html
@@ -78,7 +78,7 @@
     <ul class="breadcrumb">
       <li><a href="/">Home</a></li>
       <li><a href="/service-areas/">Service Areas</a></li>
-      <li><a href="/service-areas/north-america/usa">United States</a></li>
+      <li><a href="/service-areas/usa">United States</a></li>
       <li>Indiana</li>
     </ul>
   </nav>

--- a/service-areas/usa/iowa/index.html
+++ b/service-areas/usa/iowa/index.html
@@ -78,7 +78,7 @@
     <ul class="breadcrumb">
       <li><a href="/">Home</a></li>
       <li><a href="/service-areas/">Service Areas</a></li>
-      <li><a href="/service-areas/north-america/usa">United States</a></li>
+      <li><a href="/service-areas/usa">United States</a></li>
       <li>Iowa</li>
     </ul>
   </nav>

--- a/service-areas/usa/kentucky/index.html
+++ b/service-areas/usa/kentucky/index.html
@@ -78,7 +78,7 @@
     <ul class="breadcrumb">
       <li><a href="/">Home</a></li>
       <li><a href="/service-areas/">Service Areas</a></li>
-      <li><a href="/service-areas/north-america/usa">United States</a></li>
+      <li><a href="/service-areas/usa">United States</a></li>
       <li>Kentucky</li>
     </ul>
   </nav>

--- a/service-areas/usa/louisiana/index.html
+++ b/service-areas/usa/louisiana/index.html
@@ -78,7 +78,7 @@
     <ul class="breadcrumb">
       <li><a href="/">Home</a></li>
       <li><a href="/service-areas/">Service Areas</a></li>
-      <li><a href="/service-areas/north-america/usa">United States</a></li>
+      <li><a href="/service-areas/usa">United States</a></li>
       <li>Louisiana</li>
     </ul>
   </nav>

--- a/service-areas/usa/maryland/index.html
+++ b/service-areas/usa/maryland/index.html
@@ -78,7 +78,7 @@
     <ul class="breadcrumb">
       <li><a href="/">Home</a></li>
       <li><a href="/service-areas/">Service Areas</a></li>
-      <li><a href="/service-areas/north-america/usa">United States</a></li>
+      <li><a href="/service-areas/usa">United States</a></li>
       <li>Maryland</li>
     </ul>
   </nav>

--- a/service-areas/usa/massachusetts/index.html
+++ b/service-areas/usa/massachusetts/index.html
@@ -78,7 +78,7 @@
     <ul class="breadcrumb">
       <li><a href="/">Home</a></li>
       <li><a href="/service-areas/">Service Areas</a></li>
-      <li><a href="/service-areas/north-america/usa">United States</a></li>
+      <li><a href="/service-areas/usa">United States</a></li>
       <li>Massachusetts</li>
     </ul>
   </nav>

--- a/service-areas/usa/michigan/index.html
+++ b/service-areas/usa/michigan/index.html
@@ -78,7 +78,7 @@
     <ul class="breadcrumb">
       <li><a href="/">Home</a></li>
       <li><a href="/service-areas/">Service Areas</a></li>
-      <li><a href="/service-areas/north-america/usa">United States</a></li>
+      <li><a href="/service-areas/usa">United States</a></li>
       <li>Michigan</li>
     </ul>
   </nav>

--- a/service-areas/usa/missouri/index.html
+++ b/service-areas/usa/missouri/index.html
@@ -78,7 +78,7 @@
     <ul class="breadcrumb">
       <li><a href="/">Home</a></li>
       <li><a href="/service-areas/">Service Areas</a></li>
-      <li><a href="/service-areas/north-america/usa">United States</a></li>
+      <li><a href="/service-areas/usa">United States</a></li>
       <li>Missouri</li>
     </ul>
   </nav>

--- a/service-areas/usa/nebraska/index.html
+++ b/service-areas/usa/nebraska/index.html
@@ -78,7 +78,7 @@
     <ul class="breadcrumb">
       <li><a href="/">Home</a></li>
       <li><a href="/service-areas/">Service Areas</a></li>
-      <li><a href="/service-areas/north-america/usa">United States</a></li>
+      <li><a href="/service-areas/usa">United States</a></li>
       <li>Nebraska</li>
     </ul>
   </nav>

--- a/service-areas/usa/nevada/index.html
+++ b/service-areas/usa/nevada/index.html
@@ -78,7 +78,7 @@
     <ul class="breadcrumb">
       <li><a href="/">Home</a></li>
       <li><a href="/service-areas/">Service Areas</a></li>
-      <li><a href="/service-areas/north-america/usa">United States</a></li>
+      <li><a href="/service-areas/usa">United States</a></li>
       <li>Nevada</li>
     </ul>
   </nav>

--- a/service-areas/usa/new-mexico/index.html
+++ b/service-areas/usa/new-mexico/index.html
@@ -78,7 +78,7 @@
     <ul class="breadcrumb">
       <li><a href="/">Home</a></li>
       <li><a href="/service-areas/">Service Areas</a></li>
-      <li><a href="/service-areas/north-america/usa">United States</a></li>
+      <li><a href="/service-areas/usa">United States</a></li>
       <li>New Mexico</li>
     </ul>
   </nav>

--- a/service-areas/usa/new-york/index.html
+++ b/service-areas/usa/new-york/index.html
@@ -78,7 +78,7 @@
     <ul class="breadcrumb">
       <li><a href="/">Home</a></li>
       <li><a href="/service-areas/">Service Areas</a></li>
-      <li><a href="/service-areas/north-america/usa">United States</a></li>
+      <li><a href="/service-areas/usa">United States</a></li>
       <li>New York</li>
     </ul>
   </nav>

--- a/service-areas/usa/north-carolina/index.html
+++ b/service-areas/usa/north-carolina/index.html
@@ -78,7 +78,7 @@
     <ul class="breadcrumb">
       <li><a href="/">Home</a></li>
       <li><a href="/service-areas/">Service Areas</a></li>
-      <li><a href="/service-areas/north-america/usa">United States</a></li>
+      <li><a href="/service-areas/usa">United States</a></li>
       <li>North Carolina</li>
     </ul>
   </nav>

--- a/service-areas/usa/ohio/index.html
+++ b/service-areas/usa/ohio/index.html
@@ -78,7 +78,7 @@
     <ul class="breadcrumb">
       <li><a href="/">Home</a></li>
       <li><a href="/service-areas/">Service Areas</a></li>
-      <li><a href="/service-areas/north-america/usa">United States</a></li>
+      <li><a href="/service-areas/usa">United States</a></li>
       <li>Ohio</li>
     </ul>
   </nav>

--- a/service-areas/usa/oklahoma/index.html
+++ b/service-areas/usa/oklahoma/index.html
@@ -78,7 +78,7 @@
     <ul class="breadcrumb">
       <li><a href="/">Home</a></li>
       <li><a href="/service-areas/">Service Areas</a></li>
-      <li><a href="/service-areas/north-america/usa">United States</a></li>
+      <li><a href="/service-areas/usa">United States</a></li>
       <li>Oklahoma</li>
     </ul>
   </nav>

--- a/service-areas/usa/oregon/index.html
+++ b/service-areas/usa/oregon/index.html
@@ -78,7 +78,7 @@
     <ul class="breadcrumb">
       <li><a href="/">Home</a></li>
       <li><a href="/service-areas/">Service Areas</a></li>
-      <li><a href="/service-areas/north-america/usa">United States</a></li>
+      <li><a href="/service-areas/usa">United States</a></li>
       <li>Oregon</li>
     </ul>
   </nav>

--- a/service-areas/usa/pennsylvania/index.html
+++ b/service-areas/usa/pennsylvania/index.html
@@ -78,7 +78,7 @@
     <ul class="breadcrumb">
       <li><a href="/">Home</a></li>
       <li><a href="/service-areas/">Service Areas</a></li>
-      <li><a href="/service-areas/north-america/usa">United States</a></li>
+      <li><a href="/service-areas/usa">United States</a></li>
       <li>Pennsylvania</li>
     </ul>
   </nav>

--- a/service-areas/usa/south-carolina/index.html
+++ b/service-areas/usa/south-carolina/index.html
@@ -78,7 +78,7 @@
     <ul class="breadcrumb">
       <li><a href="/">Home</a></li>
       <li><a href="/service-areas/">Service Areas</a></li>
-      <li><a href="/service-areas/north-america/usa">United States</a></li>
+      <li><a href="/service-areas/usa">United States</a></li>
       <li>South Carolina</li>
     </ul>
   </nav>

--- a/service-areas/usa/south-dakota/index.html
+++ b/service-areas/usa/south-dakota/index.html
@@ -78,7 +78,7 @@
     <ul class="breadcrumb">
       <li><a href="/">Home</a></li>
       <li><a href="/service-areas/">Service Areas</a></li>
-      <li><a href="/service-areas/north-america/usa">United States</a></li>
+      <li><a href="/service-areas/usa">United States</a></li>
       <li>South Dakota</li>
     </ul>
   </nav>

--- a/service-areas/usa/tennessee/index.html
+++ b/service-areas/usa/tennessee/index.html
@@ -78,7 +78,7 @@
     <ul class="breadcrumb">
       <li><a href="/">Home</a></li>
       <li><a href="/service-areas/">Service Areas</a></li>
-      <li><a href="/service-areas/north-america/usa">United States</a></li>
+      <li><a href="/service-areas/usa">United States</a></li>
       <li>Tennessee</li>
     </ul>
   </nav>

--- a/service-areas/usa/texas/index.html
+++ b/service-areas/usa/texas/index.html
@@ -102,7 +102,7 @@
     <ul class="breadcrumb">
       <li><a href="/">Home</a></li>
       <li><a href="/service-areas/">Service Areas</a></li>
-      <li><a href="/service-areas/north-america/usa">United States</a></li>
+      <li><a href="/service-areas/usa">United States</a></li>
       <li>Texas</li>
     </ul>
   </nav>

--- a/service-areas/usa/utah/index.html
+++ b/service-areas/usa/utah/index.html
@@ -78,7 +78,7 @@
     <ul class="breadcrumb">
       <li><a href="/">Home</a></li>
       <li><a href="/service-areas/">Service Areas</a></li>
-      <li><a href="/service-areas/north-america/usa">United States</a></li>
+      <li><a href="/service-areas/usa">United States</a></li>
       <li>Utah</li>
     </ul>
   </nav>

--- a/service-areas/usa/virginia/index.html
+++ b/service-areas/usa/virginia/index.html
@@ -78,7 +78,7 @@
     <ul class="breadcrumb">
       <li><a href="/">Home</a></li>
       <li><a href="/service-areas/">Service Areas</a></li>
-      <li><a href="/service-areas/north-america/usa">United States</a></li>
+      <li><a href="/service-areas/usa">United States</a></li>
       <li>Virginia</li>
     </ul>
   </nav>

--- a/service-areas/usa/washington-dc/index.html
+++ b/service-areas/usa/washington-dc/index.html
@@ -78,7 +78,7 @@
     <ul class="breadcrumb">
       <li><a href="/">Home</a></li>
       <li><a href="/service-areas/">Service Areas</a></li>
-      <li><a href="/service-areas/north-america/usa">United States</a></li>
+      <li><a href="/service-areas/usa">United States</a></li>
       <li>Washington Dc</li>
     </ul>
   </nav>

--- a/service-areas/usa/washington/index.html
+++ b/service-areas/usa/washington/index.html
@@ -78,7 +78,7 @@
     <ul class="breadcrumb">
       <li><a href="/">Home</a></li>
       <li><a href="/service-areas/">Service Areas</a></li>
-      <li><a href="/service-areas/north-america/usa">United States</a></li>
+      <li><a href="/service-areas/usa">United States</a></li>
       <li>Washington</li>
     </ul>
   </nav>

--- a/service-areas/usa/west-virginia/index.html
+++ b/service-areas/usa/west-virginia/index.html
@@ -78,7 +78,7 @@
     <ul class="breadcrumb">
       <li><a href="/">Home</a></li>
       <li><a href="/service-areas/">Service Areas</a></li>
-      <li><a href="/service-areas/north-america/usa">United States</a></li>
+      <li><a href="/service-areas/usa">United States</a></li>
       <li>West Virginia</li>
     </ul>
   </nav>

--- a/service-areas/usa/wisconsin/index.html
+++ b/service-areas/usa/wisconsin/index.html
@@ -78,7 +78,7 @@
     <ul class="breadcrumb">
       <li><a href="/">Home</a></li>
       <li><a href="/service-areas/">Service Areas</a></li>
-      <li><a href="/service-areas/north-america/usa">United States</a></li>
+      <li><a href="/service-areas/usa">United States</a></li>
       <li>Wisconsin</li>
     </ul>
   </nav>


### PR DESCRIPTION
## Summary
- update breadcrumbs on all US state service pages
- update breadcrumb template in state page generator script

## Testing
- `grep -Rl "href=\"/service-areas/north-america/usa\"" | wc -l`


------
https://chatgpt.com/codex/tasks/task_e_688314734a00832cabde2cc07d5c064e