### PR TITLE
Add accordion-driven facts and FAQ for California pages

### DIFF
--- a/components/facts-accordion.html
+++ b/components/facts-accordion.html
@@ -1,0 +1,1 @@
+<section id="fast-facts" data-city="" data-state=""></section>

--- a/components/faq-accordion.html
+++ b/components/faq-accordion.html
@@ -1,0 +1,1 @@
+<section id="faq"></section>

--- a/css/accordion.css
+++ b/css/accordion.css
@@ -1,0 +1,12 @@
+#fast-facts, #faq { max-width: 900px; margin: 40px auto; padding: 0 16px; }
+#fast-facts h2, #faq h2 { color:#003366; text-align:center; margin: 0 0 18px; }
+
+.acc-item { border:1px solid #e6e6e6; border-radius:10px; margin:10px 0; overflow:hidden; background:#fff; }
+.acc-trigger {
+  width:100%; text-align:left; padding:14px 16px; font-size:1.05rem;
+  background:#156082; color:#fff; border:0; cursor:pointer; font-weight:600;
+}
+.acc-trigger[aria-expanded="true"] { background:#0f4a63; }
+.acc-panel { padding:14px 16px; line-height:1.6; }
+.acc-panel ul { margin:0; padding-left:20px; }
+.acc-panel li { margin:6px 0; }

--- a/data/locations/ca/alameda.json
+++ b/data/locations/ca/alameda.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Alameda",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Alameda and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Alameda?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Alameda and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/albany.json
+++ b/data/locations/ca/albany.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Albany",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Albany and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Albany?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Albany and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/antioch.json
+++ b/data/locations/ca/antioch.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Antioch",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Antioch and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Antioch?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Antioch and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/apc.json
+++ b/data/locations/ca/apc.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "APC Airport",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 courier coverage at APC and nearby facilities.",
+        "TSA-cleared drivers for secure cargo recovery.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside APC?",
+      "a": "Yes. We cover a ~50\u2011mile radius around APC and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo at APC?",
+      "a": "Yes. Our TSA-cleared couriers pick up from airline cargo facilities at APC and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/atherton.json
+++ b/data/locations/ca/atherton.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Atherton",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Atherton and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Atherton?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Atherton and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/bakersfield.json
+++ b/data/locations/ca/bakersfield.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Bakersfield",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Bakersfield and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Bakersfield?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Bakersfield and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/belmont.json
+++ b/data/locations/ca/belmont.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Belmont",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Belmont and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Belmont?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Belmont and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/berkeley.json
+++ b/data/locations/ca/berkeley.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Berkeley",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Berkeley and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Berkeley?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Berkeley and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/bfl.json
+++ b/data/locations/ca/bfl.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "BFL Airport",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 courier coverage at BFL and nearby facilities.",
+        "TSA-cleared drivers for secure cargo recovery.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside BFL?",
+      "a": "Yes. We cover a ~50\u2011mile radius around BFL and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo at BFL?",
+      "a": "Yes. Our TSA-cleared couriers pick up from airline cargo facilities at BFL and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/brentwood.json
+++ b/data/locations/ca/brentwood.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Brentwood",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Brentwood and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Brentwood?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Brentwood and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/bur.json
+++ b/data/locations/ca/bur.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "BUR Airport",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 courier coverage at BUR and nearby facilities.",
+        "TSA-cleared drivers for secure cargo recovery.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside BUR?",
+      "a": "Yes. We cover a ~50\u2011mile radius around BUR and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo at BUR?",
+      "a": "Yes. Our TSA-cleared couriers pick up from airline cargo facilities at BUR and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/burlingame.json
+++ b/data/locations/ca/burlingame.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Burlingame",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Burlingame and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Burlingame?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Burlingame and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/castro-valley.json
+++ b/data/locations/ca/castro-valley.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Castro Valley",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Castro Valley and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Castro Valley?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Castro Valley and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/ccr.json
+++ b/data/locations/ca/ccr.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "CCR Airport",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 courier coverage at CCR and nearby facilities.",
+        "TSA-cleared drivers for secure cargo recovery.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside CCR?",
+      "a": "Yes. We cover a ~50\u2011mile radius around CCR and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo at CCR?",
+      "a": "Yes. Our TSA-cleared couriers pick up from airline cargo facilities at CCR and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/cld.json
+++ b/data/locations/ca/cld.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "CLD Airport",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 courier coverage at CLD and nearby facilities.",
+        "TSA-cleared drivers for secure cargo recovery.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside CLD?",
+      "a": "Yes. We cover a ~50\u2011mile radius around CLD and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo at CLD?",
+      "a": "Yes. Our TSA-cleared couriers pick up from airline cargo facilities at CLD and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/cma.json
+++ b/data/locations/ca/cma.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "CMA Airport",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 courier coverage at CMA and nearby facilities.",
+        "TSA-cleared drivers for secure cargo recovery.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside CMA?",
+      "a": "Yes. We cover a ~50\u2011mile radius around CMA and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo at CMA?",
+      "a": "Yes. Our TSA-cleared couriers pick up from airline cargo facilities at CMA and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/concord.json
+++ b/data/locations/ca/concord.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Concord",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Concord and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Concord?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Concord and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/cupertino.json
+++ b/data/locations/ca/cupertino.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Cupertino",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Cupertino and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Cupertino?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Cupertino and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/danville.json
+++ b/data/locations/ca/danville.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Danville",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Danville and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Danville?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Danville and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/discovery-bay.json
+++ b/data/locations/ca/discovery-bay.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Discovery Bay",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Discovery Bay and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Discovery Bay?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Discovery Bay and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/dixon.json
+++ b/data/locations/ca/dixon.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Dixon",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Dixon and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Dixon?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Dixon and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/dublin.json
+++ b/data/locations/ca/dublin.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Dublin",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Dublin and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Dublin?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Dublin and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/dvo.json
+++ b/data/locations/ca/dvo.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "DVO Airport",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 courier coverage at DVO and nearby facilities.",
+        "TSA-cleared drivers for secure cargo recovery.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside DVO?",
+      "a": "Yes. We cover a ~50\u2011mile radius around DVO and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo at DVO?",
+      "a": "Yes. Our TSA-cleared couriers pick up from airline cargo facilities at DVO and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/el-cerrito.json
+++ b/data/locations/ca/el-cerrito.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "El Cerrito",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across El Cerrito and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside El Cerrito?",
+      "a": "Yes. We cover a ~50\u2011mile radius around El Cerrito and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/el-sobrante.json
+++ b/data/locations/ca/el-sobrante.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "El Sobrante",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across El Sobrante and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside El Sobrante?",
+      "a": "Yes. We cover a ~50\u2011mile radius around El Sobrante and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/elk-grove.json
+++ b/data/locations/ca/elk-grove.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Elk Grove",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Elk Grove and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Elk Grove?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Elk Grove and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/escalon.json
+++ b/data/locations/ca/escalon.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Escalon",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Escalon and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Escalon?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Escalon and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/fairfield.json
+++ b/data/locations/ca/fairfield.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Fairfield",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Fairfield and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Fairfield?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Fairfield and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/fat.json
+++ b/data/locations/ca/fat.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "FAT Airport",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 courier coverage at FAT and nearby facilities.",
+        "TSA-cleared drivers for secure cargo recovery.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside FAT?",
+      "a": "Yes. We cover a ~50\u2011mile radius around FAT and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo at FAT?",
+      "a": "Yes. Our TSA-cleared couriers pick up from airline cargo facilities at FAT and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/folsom.json
+++ b/data/locations/ca/folsom.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Folsom",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Folsom and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Folsom?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Folsom and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/fremont.json
+++ b/data/locations/ca/fremont.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Fremont",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Fremont and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Fremont?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Fremont and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/french-camp.json
+++ b/data/locations/ca/french-camp.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "French Camp",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across French Camp and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside French Camp?",
+      "a": "Yes. We cover a ~50\u2011mile radius around French Camp and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/fresno.json
+++ b/data/locations/ca/fresno.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Fresno",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Fresno and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Fresno?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Fresno and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/fruitvale.json
+++ b/data/locations/ca/fruitvale.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Fruitvale",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Fruitvale and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Fruitvale?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Fruitvale and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/galt.json
+++ b/data/locations/ca/galt.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Galt",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Galt and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Galt?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Galt and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/hayward.json
+++ b/data/locations/ca/hayward.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Hayward",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Hayward and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Hayward?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Hayward and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/hhr.json
+++ b/data/locations/ca/hhr.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "HHR Airport",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 courier coverage at HHR and nearby facilities.",
+        "TSA-cleared drivers for secure cargo recovery.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside HHR?",
+      "a": "Yes. We cover a ~50\u2011mile radius around HHR and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo at HHR?",
+      "a": "Yes. Our TSA-cleared couriers pick up from airline cargo facilities at HHR and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/hollywood.json
+++ b/data/locations/ca/hollywood.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Hollywood",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Hollywood and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Hollywood?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Hollywood and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/hwd.json
+++ b/data/locations/ca/hwd.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "HWD Airport",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 courier coverage at HWD and nearby facilities.",
+        "TSA-cleared drivers for secure cargo recovery.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside HWD?",
+      "a": "Yes. We cover a ~50\u2011mile radius around HWD and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo at HWD?",
+      "a": "Yes. Our TSA-cleared couriers pick up from airline cargo facilities at HWD and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/lathrop.json
+++ b/data/locations/ca/lathrop.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Lathrop",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Lathrop and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Lathrop?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Lathrop and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/lax.json
+++ b/data/locations/ca/lax.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "LAX Airport",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 courier coverage at LAX and nearby facilities.",
+        "TSA-cleared drivers for secure cargo recovery.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside LAX?",
+      "a": "Yes. We cover a ~50\u2011mile radius around LAX and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo at LAX?",
+      "a": "Yes. Our TSA-cleared couriers pick up from airline cargo facilities at LAX and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/lgb.json
+++ b/data/locations/ca/lgb.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "LGB Airport",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 courier coverage at LGB and nearby facilities.",
+        "TSA-cleared drivers for secure cargo recovery.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside LGB?",
+      "a": "Yes. We cover a ~50\u2011mile radius around LGB and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo at LGB?",
+      "a": "Yes. Our TSA-cleared couriers pick up from airline cargo facilities at LGB and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/lincoln.json
+++ b/data/locations/ca/lincoln.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Lincoln",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Lincoln and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Lincoln?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Lincoln and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/livermore.json
+++ b/data/locations/ca/livermore.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Livermore",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Livermore and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Livermore?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Livermore and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/lodi.json
+++ b/data/locations/ca/lodi.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Lodi",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Lodi and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Lodi?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Lodi and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/los-angeles.json
+++ b/data/locations/ca/los-angeles.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Los Angeles",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Los Angeles and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Los Angeles?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Los Angeles and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/los-gatos.json
+++ b/data/locations/ca/los-gatos.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Los Gatos",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Los Gatos and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Los Gatos?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Los Gatos and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/lvk.json
+++ b/data/locations/ca/lvk.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "LVK Airport",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 courier coverage at LVK and nearby facilities.",
+        "TSA-cleared drivers for secure cargo recovery.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside LVK?",
+      "a": "Yes. We cover a ~50\u2011mile radius around LVK and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo at LVK?",
+      "a": "Yes. Our TSA-cleared couriers pick up from airline cargo facilities at LVK and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/manteca.json
+++ b/data/locations/ca/manteca.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Manteca",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Manteca and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Manteca?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Manteca and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/martinez.json
+++ b/data/locations/ca/martinez.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Martinez",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Martinez and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Martinez?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Martinez and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/menlo-park.json
+++ b/data/locations/ca/menlo-park.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Menlo Park",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Menlo Park and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Menlo Park?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Menlo Park and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/milpitas.json
+++ b/data/locations/ca/milpitas.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Milpitas",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Milpitas and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Milpitas?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Milpitas and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/mod.json
+++ b/data/locations/ca/mod.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "MOD Airport",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 courier coverage at MOD and nearby facilities.",
+        "TSA-cleared drivers for secure cargo recovery.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside MOD?",
+      "a": "Yes. We cover a ~50\u2011mile radius around MOD and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo at MOD?",
+      "a": "Yes. Our TSA-cleared couriers pick up from airline cargo facilities at MOD and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/modesto.json
+++ b/data/locations/ca/modesto.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Modesto",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Modesto and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Modesto?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Modesto and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/mountain-view.json
+++ b/data/locations/ca/mountain-view.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Mountain View",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Mountain View and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Mountain View?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Mountain View and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/mry.json
+++ b/data/locations/ca/mry.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "MRY Airport",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 courier coverage at MRY and nearby facilities.",
+        "TSA-cleared drivers for secure cargo recovery.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside MRY?",
+      "a": "Yes. We cover a ~50\u2011mile radius around MRY and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo at MRY?",
+      "a": "Yes. Our TSA-cleared couriers pick up from airline cargo facilities at MRY and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/napa.json
+++ b/data/locations/ca/napa.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Napa",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Napa and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Napa?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Napa and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/oak.json
+++ b/data/locations/ca/oak.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "OAK Airport",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 courier coverage at OAK and nearby facilities.",
+        "TSA-cleared drivers for secure cargo recovery.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside OAK?",
+      "a": "Yes. We cover a ~50\u2011mile radius around OAK and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo at OAK?",
+      "a": "Yes. Our TSA-cleared couriers pick up from airline cargo facilities at OAK and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/oakdale.json
+++ b/data/locations/ca/oakdale.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Oakdale",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Oakdale and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Oakdale?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Oakdale and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/oakland.json
+++ b/data/locations/ca/oakland.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Oakland",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Oakland and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Oakland?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Oakland and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/ont.json
+++ b/data/locations/ca/ont.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "ONT Airport",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 courier coverage at ONT and nearby facilities.",
+        "TSA-cleared drivers for secure cargo recovery.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside ONT?",
+      "a": "Yes. We cover a ~50\u2011mile radius around ONT and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo at ONT?",
+      "a": "Yes. Our TSA-cleared couriers pick up from airline cargo facilities at ONT and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/ontario.json
+++ b/data/locations/ca/ontario.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Ontario",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Ontario and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Ontario?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Ontario and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/orange-county.json
+++ b/data/locations/ca/orange-county.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Orange County",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Orange County and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Orange County?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Orange County and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/pacheco.json
+++ b/data/locations/ca/pacheco.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Pacheco",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Pacheco and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Pacheco?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Pacheco and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/palo-alto.json
+++ b/data/locations/ca/palo-alto.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Palo Alto",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Palo Alto and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Palo Alto?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Palo Alto and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/pao.json
+++ b/data/locations/ca/pao.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "PAO Airport",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 courier coverage at PAO and nearby facilities.",
+        "TSA-cleared drivers for secure cargo recovery.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside PAO?",
+      "a": "Yes. We cover a ~50\u2011mile radius around PAO and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo at PAO?",
+      "a": "Yes. Our TSA-cleared couriers pick up from airline cargo facilities at PAO and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/piedmont.json
+++ b/data/locations/ca/piedmont.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Piedmont",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Piedmont and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Piedmont?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Piedmont and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/pittsburg.json
+++ b/data/locations/ca/pittsburg.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Pittsburg",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Pittsburg and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Pittsburg?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Pittsburg and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/pleasant-hill.json
+++ b/data/locations/ca/pleasant-hill.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Pleasant Hill",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Pleasant Hill and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Pleasant Hill?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Pleasant Hill and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/pleasanton.json
+++ b/data/locations/ca/pleasanton.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Pleasanton",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Pleasanton and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Pleasanton?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Pleasanton and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/rancho-cordova.json
+++ b/data/locations/ca/rancho-cordova.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Rancho Cordova",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Rancho Cordova and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Rancho Cordova?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Rancho Cordova and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/redwood-city.json
+++ b/data/locations/ca/redwood-city.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Redwood City",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Redwood City and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Redwood City?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Redwood City and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/rhv.json
+++ b/data/locations/ca/rhv.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "RHV Airport",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 courier coverage at RHV and nearby facilities.",
+        "TSA-cleared drivers for secure cargo recovery.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside RHV?",
+      "a": "Yes. We cover a ~50\u2011mile radius around RHV and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo at RHV?",
+      "a": "Yes. Our TSA-cleared couriers pick up from airline cargo facilities at RHV and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/richmond.json
+++ b/data/locations/ca/richmond.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Richmond",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Richmond and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Richmond?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Richmond and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/ripon.json
+++ b/data/locations/ca/ripon.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Ripon",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Ripon and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Ripon?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Ripon and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/roseville.json
+++ b/data/locations/ca/roseville.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Roseville",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Roseville and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Roseville?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Roseville and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/sac.json
+++ b/data/locations/ca/sac.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "SAC Airport",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 courier coverage at SAC and nearby facilities.",
+        "TSA-cleared drivers for secure cargo recovery.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside SAC?",
+      "a": "Yes. We cover a ~50\u2011mile radius around SAC and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo at SAC?",
+      "a": "Yes. Our TSA-cleared couriers pick up from airline cargo facilities at SAC and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/sacramento.json
+++ b/data/locations/ca/sacramento.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Sacramento",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Sacramento and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Sacramento?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Sacramento and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/salida.json
+++ b/data/locations/ca/salida.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Salida",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Salida and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Salida?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Salida and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/san-bernardino.json
+++ b/data/locations/ca/san-bernardino.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "San Bernardino",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across San Bernardino and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside San Bernardino?",
+      "a": "Yes. We cover a ~50\u2011mile radius around San Bernardino and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/san-bruno.json
+++ b/data/locations/ca/san-bruno.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "San Bruno",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across San Bruno and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside San Bruno?",
+      "a": "Yes. We cover a ~50\u2011mile radius around San Bruno and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/san-carlos.json
+++ b/data/locations/ca/san-carlos.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "San Carlos",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across San Carlos and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside San Carlos?",
+      "a": "Yes. We cover a ~50\u2011mile radius around San Carlos and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/san-diego.json
+++ b/data/locations/ca/san-diego.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "San Diego",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across San Diego and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside San Diego?",
+      "a": "Yes. We cover a ~50\u2011mile radius around San Diego and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/san-francisco.json
+++ b/data/locations/ca/san-francisco.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "San Francisco",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across San Francisco and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside San Francisco?",
+      "a": "Yes. We cover a ~50\u2011mile radius around San Francisco and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/san-jose.json
+++ b/data/locations/ca/san-jose.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "San Jose",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across San Jose and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside San Jose?",
+      "a": "Yes. We cover a ~50\u2011mile radius around San Jose and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/san-leandro.json
+++ b/data/locations/ca/san-leandro.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "San Leandro",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across San Leandro and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside San Leandro?",
+      "a": "Yes. We cover a ~50\u2011mile radius around San Leandro and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/san-mateo.json
+++ b/data/locations/ca/san-mateo.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "San Mateo",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across San Mateo and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside San Mateo?",
+      "a": "Yes. We cover a ~50\u2011mile radius around San Mateo and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/san-pablo.json
+++ b/data/locations/ca/san-pablo.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "San Pablo",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across San Pablo and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside San Pablo?",
+      "a": "Yes. We cover a ~50\u2011mile radius around San Pablo and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/san-rafael.json
+++ b/data/locations/ca/san-rafael.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "San Rafael",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across San Rafael and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside San Rafael?",
+      "a": "Yes. We cover a ~50\u2011mile radius around San Rafael and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/san-ramon.json
+++ b/data/locations/ca/san-ramon.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "San Ramon",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across San Ramon and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside San Ramon?",
+      "a": "Yes. We cover a ~50\u2011mile radius around San Ramon and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/san.json
+++ b/data/locations/ca/san.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "SAN Airport",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 courier coverage at SAN and nearby facilities.",
+        "TSA-cleared drivers for secure cargo recovery.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside SAN?",
+      "a": "Yes. We cover a ~50\u2011mile radius around SAN and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo at SAN?",
+      "a": "Yes. Our TSA-cleared couriers pick up from airline cargo facilities at SAN and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/santa-clara.json
+++ b/data/locations/ca/santa-clara.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Santa Clara",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Santa Clara and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Santa Clara?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Santa Clara and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/santa-monica.json
+++ b/data/locations/ca/santa-monica.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Santa Monica",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Santa Monica and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Santa Monica?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Santa Monica and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/santa-rosa.json
+++ b/data/locations/ca/santa-rosa.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Santa Rosa",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Santa Rosa and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Santa Rosa?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Santa Rosa and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/santa-teresa.json
+++ b/data/locations/ca/santa-teresa.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Santa Teresa",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Santa Teresa and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Santa Teresa?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Santa Teresa and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/sbd.json
+++ b/data/locations/ca/sbd.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "SBD Airport",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 courier coverage at SBD and nearby facilities.",
+        "TSA-cleared drivers for secure cargo recovery.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside SBD?",
+      "a": "Yes. We cover a ~50\u2011mile radius around SBD and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo at SBD?",
+      "a": "Yes. Our TSA-cleared couriers pick up from airline cargo facilities at SBD and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/sck.json
+++ b/data/locations/ca/sck.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "SCK Airport",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 courier coverage at SCK and nearby facilities.",
+        "TSA-cleared drivers for secure cargo recovery.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside SCK?",
+      "a": "Yes. We cover a ~50\u2011mile radius around SCK and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo at SCK?",
+      "a": "Yes. Our TSA-cleared couriers pick up from airline cargo facilities at SCK and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/see.json
+++ b/data/locations/ca/see.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "SEE Airport",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 courier coverage at SEE and nearby facilities.",
+        "TSA-cleared drivers for secure cargo recovery.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside SEE?",
+      "a": "Yes. We cover a ~50\u2011mile radius around SEE and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo at SEE?",
+      "a": "Yes. Our TSA-cleared couriers pick up from airline cargo facilities at SEE and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/sfo.json
+++ b/data/locations/ca/sfo.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "SFO Airport",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 courier coverage at SFO and nearby facilities.",
+        "TSA-cleared drivers for secure cargo recovery.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside SFO?",
+      "a": "Yes. We cover a ~50\u2011mile radius around SFO and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo at SFO?",
+      "a": "Yes. Our TSA-cleared couriers pick up from airline cargo facilities at SFO and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/sjc.json
+++ b/data/locations/ca/sjc.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "SJC Airport",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 courier coverage at SJC and nearby facilities.",
+        "TSA-cleared drivers for secure cargo recovery.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside SJC?",
+      "a": "Yes. We cover a ~50\u2011mile radius around SJC and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo at SJC?",
+      "a": "Yes. Our TSA-cleared couriers pick up from airline cargo facilities at SJC and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/smf.json
+++ b/data/locations/ca/smf.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "SMF Airport",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 courier coverage at SMF and nearby facilities.",
+        "TSA-cleared drivers for secure cargo recovery.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside SMF?",
+      "a": "Yes. We cover a ~50\u2011mile radius around SMF and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo at SMF?",
+      "a": "Yes. Our TSA-cleared couriers pick up from airline cargo facilities at SMF and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/smo.json
+++ b/data/locations/ca/smo.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "SMO Airport",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 courier coverage at SMO and nearby facilities.",
+        "TSA-cleared drivers for secure cargo recovery.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside SMO?",
+      "a": "Yes. We cover a ~50\u2011mile radius around SMO and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo at SMO?",
+      "a": "Yes. Our TSA-cleared couriers pick up from airline cargo facilities at SMO and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/sna.json
+++ b/data/locations/ca/sna.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "SNA Airport",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 courier coverage at SNA and nearby facilities.",
+        "TSA-cleared drivers for secure cargo recovery.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside SNA?",
+      "a": "Yes. We cover a ~50\u2011mile radius around SNA and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo at SNA?",
+      "a": "Yes. Our TSA-cleared couriers pick up from airline cargo facilities at SNA and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/sonoma.json
+++ b/data/locations/ca/sonoma.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Sonoma",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Sonoma and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Sonoma?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Sonoma and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/sql.json
+++ b/data/locations/ca/sql.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "SQL Airport",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 courier coverage at SQL and nearby facilities.",
+        "TSA-cleared drivers for secure cargo recovery.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside SQL?",
+      "a": "Yes. We cover a ~50\u2011mile radius around SQL and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo at SQL?",
+      "a": "Yes. Our TSA-cleared couriers pick up from airline cargo facilities at SQL and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/standford.json
+++ b/data/locations/ca/standford.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Standford",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Standford and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Standford?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Standford and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/stockton.json
+++ b/data/locations/ca/stockton.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Stockton",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Stockton and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Stockton?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Stockton and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/sts.json
+++ b/data/locations/ca/sts.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "STS Airport",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 courier coverage at STS and nearby facilities.",
+        "TSA-cleared drivers for secure cargo recovery.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside STS?",
+      "a": "Yes. We cover a ~50\u2011mile radius around STS and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo at STS?",
+      "a": "Yes. Our TSA-cleared couriers pick up from airline cargo facilities at STS and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/sunnyvale.json
+++ b/data/locations/ca/sunnyvale.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Sunnyvale",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Sunnyvale and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Sunnyvale?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Sunnyvale and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/toa.json
+++ b/data/locations/ca/toa.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "TOA Airport",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 courier coverage at TOA and nearby facilities.",
+        "TSA-cleared drivers for secure cargo recovery.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside TOA?",
+      "a": "Yes. We cover a ~50\u2011mile radius around TOA and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo at TOA?",
+      "a": "Yes. Our TSA-cleared couriers pick up from airline cargo facilities at TOA and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/tracy.json
+++ b/data/locations/ca/tracy.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Tracy",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Tracy and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Tracy?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Tracy and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/union-city.json
+++ b/data/locations/ca/union-city.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Union City",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Union City and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Union City?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Union City and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/vny.json
+++ b/data/locations/ca/vny.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "VNY Airport",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 courier coverage at VNY and nearby facilities.",
+        "TSA-cleared drivers for secure cargo recovery.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside VNY?",
+      "a": "Yes. We cover a ~50\u2011mile radius around VNY and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo at VNY?",
+      "a": "Yes. Our TSA-cleared couriers pick up from airline cargo facilities at VNY and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/walnut-creek.json
+++ b/data/locations/ca/walnut-creek.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Walnut Creek",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Walnut Creek and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Walnut Creek?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Walnut Creek and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/data/locations/ca/warm-springs.json
+++ b/data/locations/ca/warm-springs.json
@@ -1,0 +1,48 @@
+{
+  "location": {
+    "city": "Warm Springs",
+    "state": "CA",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Warm Springs and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Warm Springs?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Warm Springs and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in California?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from California airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    }
+  ]
+}

--- a/js/accordion.js
+++ b/js/accordion.js
@@ -1,0 +1,63 @@
+(function(){
+  if(window.__accordionInit) return;
+  window.__accordionInit = true;
+
+  async function init(){
+    const factsEl = document.querySelector('#fast-facts');
+    const faqEl = document.querySelector('#faq');
+    if(!factsEl || !faqEl) return;
+
+    const city = factsEl.dataset.city && factsEl.dataset.city.trim();
+    const state = factsEl.dataset.state && factsEl.dataset.state.trim();
+    if(!city || !state) return;
+
+    const slug = s => s.toLowerCase().replace(/\s+/g,'-');
+
+    try {
+      const res = await fetch(`/data/locations/${state.toLowerCase()}/${slug(city)}.json`);
+      if(!res.ok) throw new Error('Data not found');
+      const data = await res.json();
+
+      factsEl.innerHTML = `\n      <h2>Quick Facts – ${data.location.city}, ${data.location.state} Courier Services</h2>\n      ${data.facts.map((group,i)=>`\n        <div class="acc-item">\n          <button class="acc-trigger" aria-expanded="false" aria-controls="fact-${i}" id="fact-label-${i}">\n            ${group.title}\n          </button>\n          <div class="acc-panel" id="fact-${i}" role="region" aria-labelledby="fact-label-${i}">\n            <ul>${group.items.map(li=>`<li>${li}</li>`).join('')}</ul>\n          </div>\n        </div>\n      `).join('')}\n    `;
+
+      faqEl.innerHTML = `\n      <h2>${data.location.city} Courier – FAQs</h2>\n      ${data.faq.map((qa,i)=>`\n        <div class="acc-item">\n          <button class="acc-trigger" aria-expanded="false" aria-controls="faq-${i}" id="faq-label-${i}">\n            ${qa.q}\n          </button>\n          <div class="acc-panel" id="faq-${i}" role="region" aria-labelledby="faq-label-${i}">\n            <p>${qa.a}</p>\n          </div>\n        </div>\n      `).join('')}\n    `;
+
+      const triggers = Array.from(document.querySelectorAll('.acc-trigger'));
+      triggers.forEach((btn,idx)=>{
+        const panel = document.getElementById(btn.getAttribute('aria-controls'));
+        panel.hidden = true;
+        const toggle = ()=>{
+          const expanded = btn.getAttribute('aria-expanded')==='true';
+          btn.setAttribute('aria-expanded', String(!expanded));
+          panel.hidden = expanded;
+          if(!expanded && window.gtag) {
+            window.gtag('event','accordion_open',{section: btn.textContent.trim(), page_type:'local_landing'});
+          }
+        };
+        btn.addEventListener('click', toggle);
+        btn.addEventListener('keydown', e=>{
+          if(e.key===' '||e.key==='Enter'){e.preventDefault();toggle();}
+          else if(e.key==='ArrowDown'){e.preventDefault();triggers[(idx+1)%triggers.length].focus();}
+          else if(e.key==='ArrowUp'){e.preventDefault();triggers[(idx-1+triggers.length)%triggers.length].focus();}
+        });
+      });
+
+      if(!document.getElementById('faq-schema')){
+        const faqSchema={
+          "@context":"https://schema.org",
+          "@type":"FAQPage",
+          "mainEntity":data.faq.map(qa=>({"@type":"Question","name":qa.q,"acceptedAnswer":{"@type":"Answer","text":qa.a}}))
+        };
+        const s=document.createElement('script');
+        s.type='application/ld+json';
+        s.id='faq-schema';
+        s.textContent=JSON.stringify(faqSchema);
+        document.head.appendChild(s);
+      }
+    } catch(e) {
+      console.warn('Accordion init failed', e);
+    }
+  }
+
+  init();
+})();

--- a/service-areas/usa/airport/apc/index.html
+++ b/service-areas/usa/airport/apc/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="APC" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/airport/bfl/index.html
+++ b/service-areas/usa/airport/bfl/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="BFL" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/airport/bur/index.html
+++ b/service-areas/usa/airport/bur/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="BUR" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/airport/ccr/index.html
+++ b/service-areas/usa/airport/ccr/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="CCR" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/airport/cld/index.html
+++ b/service-areas/usa/airport/cld/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="CLD" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/airport/cma/index.html
+++ b/service-areas/usa/airport/cma/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="CMA" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/airport/dvo/index.html
+++ b/service-areas/usa/airport/dvo/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="DVO" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/airport/fat/index.html
+++ b/service-areas/usa/airport/fat/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="FAT" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/airport/hhr/index.html
+++ b/service-areas/usa/airport/hhr/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="HHR" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/airport/hwd/index.html
+++ b/service-areas/usa/airport/hwd/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="HWD" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/airport/lax/index.html
+++ b/service-areas/usa/airport/lax/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="LAX" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/airport/lgb/index.html
+++ b/service-areas/usa/airport/lgb/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="LGB" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/airport/lvk/index.html
+++ b/service-areas/usa/airport/lvk/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="LVK" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/airport/mod/index.html
+++ b/service-areas/usa/airport/mod/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="MOD" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/airport/mry/index.html
+++ b/service-areas/usa/airport/mry/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="MRY" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/airport/oak/index.html
+++ b/service-areas/usa/airport/oak/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="OAK" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/airport/ont/index.html
+++ b/service-areas/usa/airport/ont/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="ONT" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/airport/pao/index.html
+++ b/service-areas/usa/airport/pao/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="PAO" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/airport/rhv/index.html
+++ b/service-areas/usa/airport/rhv/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="RHV" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/airport/sac/index.html
+++ b/service-areas/usa/airport/sac/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="SAC" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/airport/san/index.html
+++ b/service-areas/usa/airport/san/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="SAN" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/airport/sbd/index.html
+++ b/service-areas/usa/airport/sbd/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="SBD" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/airport/sck/index.html
+++ b/service-areas/usa/airport/sck/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="SCK" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/airport/see/index.html
+++ b/service-areas/usa/airport/see/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="SEE" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/airport/sfo/index.html
+++ b/service-areas/usa/airport/sfo/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="SFO" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/airport/sjc/index.html
+++ b/service-areas/usa/airport/sjc/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="SJC" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/airport/smf/index.html
+++ b/service-areas/usa/airport/smf/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="SMF" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/airport/smo/index.html
+++ b/service-areas/usa/airport/smo/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="SMO" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/airport/sna/index.html
+++ b/service-areas/usa/airport/sna/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="SNA" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/airport/sql/index.html
+++ b/service-areas/usa/airport/sql/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="SQL" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/airport/sts/index.html
+++ b/service-areas/usa/airport/sts/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="STS" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/airport/toa/index.html
+++ b/service-areas/usa/airport/toa/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="TOA" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/airport/vny/index.html
+++ b/service-areas/usa/airport/vny/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="VNY" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/alameda/index.html
+++ b/service-areas/usa/california/alameda/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Alameda" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/albany/index.html
+++ b/service-areas/usa/california/albany/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Albany" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/antioch/index.html
+++ b/service-areas/usa/california/antioch/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Antioch" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/atherton/index.html
+++ b/service-areas/usa/california/atherton/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Atherton" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/bakersfield/index.html
+++ b/service-areas/usa/california/bakersfield/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Bakersfield" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/belmont/index.html
+++ b/service-areas/usa/california/belmont/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Belmont" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/berkeley/index.html
+++ b/service-areas/usa/california/berkeley/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Berkeley" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/brentwood/index.html
+++ b/service-areas/usa/california/brentwood/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Brentwood" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/burlingame/index.html
+++ b/service-areas/usa/california/burlingame/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Burlingame" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/castro-valley/index.html
+++ b/service-areas/usa/california/castro-valley/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Castro Valley" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/concord/index.html
+++ b/service-areas/usa/california/concord/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Concord" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/cupertino/index.html
+++ b/service-areas/usa/california/cupertino/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Cupertino" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/danville/index.html
+++ b/service-areas/usa/california/danville/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Danville" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/discovery-bay/index.html
+++ b/service-areas/usa/california/discovery-bay/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Discovery Bay" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/dixon/index.html
+++ b/service-areas/usa/california/dixon/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Dixon" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/dublin/index.html
+++ b/service-areas/usa/california/dublin/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Dublin" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/el-cerrito/index.html
+++ b/service-areas/usa/california/el-cerrito/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="El Cerrito" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/el-sobrante/index.html
+++ b/service-areas/usa/california/el-sobrante/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="El Sobrante" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/elk-grove/index.html
+++ b/service-areas/usa/california/elk-grove/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Elk Grove" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/escalon/index.html
+++ b/service-areas/usa/california/escalon/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Escalon" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/fairfield/index.html
+++ b/service-areas/usa/california/fairfield/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Fairfield" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/folsom/index.html
+++ b/service-areas/usa/california/folsom/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Folsom" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/fremont/index.html
+++ b/service-areas/usa/california/fremont/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Fremont" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/french-camp/index.html
+++ b/service-areas/usa/california/french-camp/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="French Camp" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/fresno/index.html
+++ b/service-areas/usa/california/fresno/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Fresno" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/fruitvale/index.html
+++ b/service-areas/usa/california/fruitvale/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Fruitvale" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/galt/index.html
+++ b/service-areas/usa/california/galt/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Galt" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/hayward/index.html
+++ b/service-areas/usa/california/hayward/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Hayward" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/hollywood/index.html
+++ b/service-areas/usa/california/hollywood/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Hollywood" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/lathrop/index.html
+++ b/service-areas/usa/california/lathrop/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Lathrop" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/lincoln/index.html
+++ b/service-areas/usa/california/lincoln/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Lincoln" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/livermore/index.html
+++ b/service-areas/usa/california/livermore/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Livermore" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/lodi/index.html
+++ b/service-areas/usa/california/lodi/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Lodi" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/los-angeles/index.html
+++ b/service-areas/usa/california/los-angeles/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Los Angeles" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/los-gatos/index.html
+++ b/service-areas/usa/california/los-gatos/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Los Gatos" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/manteca/index.html
+++ b/service-areas/usa/california/manteca/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Manteca" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/martinez/index.html
+++ b/service-areas/usa/california/martinez/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Martinez" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/menlo-park/index.html
+++ b/service-areas/usa/california/menlo-park/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Menlo Park" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/milpitas/index.html
+++ b/service-areas/usa/california/milpitas/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Milpitas" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/modesto/index.html
+++ b/service-areas/usa/california/modesto/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Modesto" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/mountain-view/index.html
+++ b/service-areas/usa/california/mountain-view/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Mountain View" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/napa/index.html
+++ b/service-areas/usa/california/napa/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Napa" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/oakdale/index.html
+++ b/service-areas/usa/california/oakdale/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Oakdale" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/oakland/index.html
+++ b/service-areas/usa/california/oakland/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Oakland" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/ontario/index.html
+++ b/service-areas/usa/california/ontario/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Ontario" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/orange-county/index.html
+++ b/service-areas/usa/california/orange-county/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Orange County" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/pacheco/index.html
+++ b/service-areas/usa/california/pacheco/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Pacheco" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/palo-alto/index.html
+++ b/service-areas/usa/california/palo-alto/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Palo Alto" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/piedmont/index.html
+++ b/service-areas/usa/california/piedmont/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Piedmont" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/pittsburg/index.html
+++ b/service-areas/usa/california/pittsburg/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Pittsburg" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/pleasant-hill/index.html
+++ b/service-areas/usa/california/pleasant-hill/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Pleasant Hill" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/pleasanton/index.html
+++ b/service-areas/usa/california/pleasanton/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Pleasanton" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/rancho-cordova/index.html
+++ b/service-areas/usa/california/rancho-cordova/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Rancho Cordova" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/redwood-city/index.html
+++ b/service-areas/usa/california/redwood-city/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Redwood City" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/richmond/index.html
+++ b/service-areas/usa/california/richmond/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Richmond" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/ripon/index.html
+++ b/service-areas/usa/california/ripon/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Ripon" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/roseville/index.html
+++ b/service-areas/usa/california/roseville/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Roseville" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/sacramento/index.html
+++ b/service-areas/usa/california/sacramento/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Sacramento" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/salida/index.html
+++ b/service-areas/usa/california/salida/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Salida" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/san-bernardino/index.html
+++ b/service-areas/usa/california/san-bernardino/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="San Bernardino" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/san-bruno/index.html
+++ b/service-areas/usa/california/san-bruno/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="San Bruno" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/san-carlos/index.html
+++ b/service-areas/usa/california/san-carlos/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="San Carlos" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/san-diego/index.html
+++ b/service-areas/usa/california/san-diego/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="San Diego" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/san-francisco/index.html
+++ b/service-areas/usa/california/san-francisco/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="San Francisco" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/san-jose/index.html
+++ b/service-areas/usa/california/san-jose/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="San Jose" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/san-leandro/index.html
+++ b/service-areas/usa/california/san-leandro/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="San Leandro" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/san-mateo/index.html
+++ b/service-areas/usa/california/san-mateo/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="San Mateo" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/san-pablo/index.html
+++ b/service-areas/usa/california/san-pablo/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="San Pablo" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/san-rafael/index.html
+++ b/service-areas/usa/california/san-rafael/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="San Rafael" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/san-ramon/index.html
+++ b/service-areas/usa/california/san-ramon/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="San Ramon" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/santa-clara/index.html
+++ b/service-areas/usa/california/santa-clara/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Santa Clara" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/santa-monica/index.html
+++ b/service-areas/usa/california/santa-monica/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Santa Monica" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/santa-rosa/index.html
+++ b/service-areas/usa/california/santa-rosa/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Santa Rosa" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/santa-teresa/index.html
+++ b/service-areas/usa/california/santa-teresa/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Santa Teresa" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/sonoma/index.html
+++ b/service-areas/usa/california/sonoma/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Sonoma" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/standford/index.html
+++ b/service-areas/usa/california/standford/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Standford" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/stockton/index.html
+++ b/service-areas/usa/california/stockton/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Stockton" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/sunnyvale/index.html
+++ b/service-areas/usa/california/sunnyvale/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Sunnyvale" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/tracy/index.html
+++ b/service-areas/usa/california/tracy/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Tracy" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/union-city/index.html
+++ b/service-areas/usa/california/union-city/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Union City" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/walnut-creek/index.html
+++ b/service-areas/usa/california/walnut-creek/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Walnut Creek" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())

--- a/service-areas/usa/california/warm-springs/index.html
+++ b/service-areas/usa/california/warm-springs/index.html
@@ -14,6 +14,7 @@
   <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
   <link href="/site.webmanifest" rel="manifest"/>
   <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
 </head>
 <body>
 <div id="navbar-placeholder"></div>
@@ -89,7 +90,10 @@
     </div>
   </div>
 </section>
+<section id="fast-facts" data-city="Warm Springs" data-state="CA"></section>
+<section id="faq"></section>
 <div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
 <script defer>
   fetch('/components/footer.html')
     .then(res => res.text())


### PR DESCRIPTION
## Summary
- add reusable accordion script and styles
- source FAQ and fact content from new JSON files for each CA city and airport
- embed fast-facts and FAQ sections across California location and airport pages

## Testing
- `node --check js/accordion.js`
- `python -m py_compile scripts/generate_california_city_pages.py scripts/generate_california_airport_pages.py scripts/generate_state_pages.py`


------
https://chatgpt.com/codex/tasks/task_e_68957dc4bb34832ca2d38c4bb72f2508