### PR TITLE
Display quick facts and FAQs side by side

### DIFF
--- a/css/accordion.css
+++ b/css/accordion.css
@@ -1,4 +1,17 @@
-#fast-facts, #faq { max-width: 900px; margin: 40px auto; padding: 0 16px; }
+
+.facts-faq-wrapper {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 40px;
+  max-width: 900px;
+  margin: 40px auto;
+}
+
+#fast-facts, #faq {
+  flex: 1 1 400px;
+  padding: 0 16px;
+}
+
 #fast-facts h2, #faq h2 { color:#003366; text-align:center; margin: 0 0 18px; }
 
 .acc-item { border:1px solid #e6e6e6; border-radius:10px; margin:10px 0; overflow:hidden; background:#fff; }

--- a/js/accordion.js
+++ b/js/accordion.js
@@ -11,6 +11,13 @@
     const state = factsEl.dataset.state && factsEl.dataset.state.trim();
     if(!city || !state) return;
 
+    // Wrap the fast facts and FAQ sections so they can sit side by side
+    const wrapper = document.createElement('div');
+    wrapper.className = 'facts-faq-wrapper';
+    factsEl.parentNode.insertBefore(wrapper, factsEl);
+    wrapper.appendChild(factsEl);
+    wrapper.appendChild(faqEl);
+
     const slug = s => s.toLowerCase().replace(/\s+/g,'-');
 
     try {


### PR DESCRIPTION
## Summary
- Wrap quick facts and FAQ sections in a shared container to support side-by-side layout on service pages.
- Add flexbox styling for the new wrapper and sections.

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689580cffbd4832cb60069ee129469e9