### PR TITLE
Add New Jersey city pages and location data

### DIFF
--- a/data/locations/nj/atlantic-city.json
+++ b/data/locations/nj/atlantic-city.json
@@ -1,0 +1,129 @@
+{
+  "location": {
+    "city": "Atlantic City",
+    "state": "NJ",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Atlantic City and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Atlantic City?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Atlantic City and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in New Jersey?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from New Jersey airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    },
+    {
+      "q": "How fast can you deliver from Atlantic City to nearby cities?",
+      "a": "Most deliveries from Atlantic City to neighboring areas arrive the same day thanks to our dedicated courier network."
+    }
+  ],
+  "hero": {
+    "h1": "Atlantic City, NJ Courier & Delivery Services",
+    "intro": "Fast same-day, freight, and medical deliveries across Atlantic City."
+  },
+  "fastFacts": [
+    {
+      "type": "short",
+      "title": "Service Radius",
+      "content": "50-mile coverage",
+      "seo": "Atlantic City courier delivery radius 50 miles"
+    },
+    {
+      "type": "short",
+      "title": "Availability",
+      "content": "24/7 dispatch",
+      "seo": "Atlantic City 24/7 courier service"
+    },
+    {
+      "type": "long",
+      "title": "Local Expertise",
+      "content": "Atlantic City couriers know the area, using optimal routes for fast <strong>same-day delivery</strong>.",
+      "seo": "Atlantic City same-day delivery courier"
+    },
+    {
+      "type": "long",
+      "title": "Business District",
+      "content": "Central Atlantic City districts enable quick pickups and drop-offs for offices and retail.",
+      "seo": "Atlantic City business courier services"
+    },
+    {
+      "type": "long",
+      "title": "Medical Logistics",
+      "content": "Hospitals and labs in Atlantic City rely on our <strong>medical courier</strong> team for urgent transport.",
+      "seo": "Atlantic City medical courier services"
+    },
+    {
+      "type": "long",
+      "title": "Freight Capacity",
+      "content": "From cargo vans to box trucks, we handle heavy freight in Atlantic City and beyond.",
+      "seo": "Atlantic City freight delivery"
+    }
+  ],
+  "pois": [
+    {
+      "name": "Atlantic City City Hall",
+      "category": "Government",
+      "description": "Regular route stop for document filings and legal <strong>courier service in Atlantic City</strong>."
+    },
+    {
+      "name": "Atlantic City Business District",
+      "category": "Business District",
+      "description": "Dense cluster of offices\u2014ideal for bulk <strong>same-day deliveries</strong> in Atlantic City."
+    },
+    {
+      "name": "Atlantic City Medical Center",
+      "category": "Hospital",
+      "description": "Key destination for <strong>medical courier</strong> runs serving Atlantic City healthcare providers."
+    }
+  ],
+  "coverage": {
+    "county": "Atlantic County",
+    "description": "Serving all neighborhoods in and around Atlantic City with <strong>same-day</strong> and <strong>freight courier</strong> options."
+  },
+  "testimonials": [
+    {
+      "quote": "\u201cCordova Courier keeps our Atlantic City operations moving.\u201d",
+      "author": "Local Business Owner"
+    },
+    {
+      "quote": "\u201cFast delivery across Atlantic City every time.\u201d",
+      "author": "Operations Manager"
+    },
+    {
+      "quote": "\u201cReliable Atlantic City courier service we trust for urgent shipments.\u201d",
+      "author": "Logistics Coordinator"
+    }
+  ]
+}

--- a/data/locations/nj/jersey-city.json
+++ b/data/locations/nj/jersey-city.json
@@ -1,0 +1,129 @@
+{
+  "location": {
+    "city": "Jersey City",
+    "state": "NJ",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Jersey City and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Jersey City?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Jersey City and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in New Jersey?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from New Jersey airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    },
+    {
+      "q": "How fast can you deliver from Jersey City to nearby cities?",
+      "a": "Most deliveries from Jersey City to neighboring areas arrive the same day thanks to our dedicated courier network."
+    }
+  ],
+  "hero": {
+    "h1": "Jersey City, NJ Courier & Delivery Services",
+    "intro": "Fast same-day, freight, and medical deliveries across Jersey City."
+  },
+  "fastFacts": [
+    {
+      "type": "short",
+      "title": "Service Radius",
+      "content": "50-mile coverage",
+      "seo": "Jersey City courier delivery radius 50 miles"
+    },
+    {
+      "type": "short",
+      "title": "Availability",
+      "content": "24/7 dispatch",
+      "seo": "Jersey City 24/7 courier service"
+    },
+    {
+      "type": "long",
+      "title": "Local Expertise",
+      "content": "Jersey City couriers know the area, using optimal routes for fast <strong>same-day delivery</strong>.",
+      "seo": "Jersey City same-day delivery courier"
+    },
+    {
+      "type": "long",
+      "title": "Business District",
+      "content": "Central Jersey City districts enable quick pickups and drop-offs for offices and retail.",
+      "seo": "Jersey City business courier services"
+    },
+    {
+      "type": "long",
+      "title": "Medical Logistics",
+      "content": "Hospitals and labs in Jersey City rely on our <strong>medical courier</strong> team for urgent transport.",
+      "seo": "Jersey City medical courier services"
+    },
+    {
+      "type": "long",
+      "title": "Freight Capacity",
+      "content": "From cargo vans to box trucks, we handle heavy freight in Jersey City and beyond.",
+      "seo": "Jersey City freight delivery"
+    }
+  ],
+  "pois": [
+    {
+      "name": "Jersey City City Hall",
+      "category": "Government",
+      "description": "Regular route stop for document filings and legal <strong>courier service in Jersey City</strong>."
+    },
+    {
+      "name": "Jersey City Business District",
+      "category": "Business District",
+      "description": "Dense cluster of offices\u2014ideal for bulk <strong>same-day deliveries</strong> in Jersey City."
+    },
+    {
+      "name": "Jersey City Medical Center",
+      "category": "Hospital",
+      "description": "Key destination for <strong>medical courier</strong> runs serving Jersey City healthcare providers."
+    }
+  ],
+  "coverage": {
+    "county": "Hudson County",
+    "description": "Serving all neighborhoods in and around Jersey City with <strong>same-day</strong> and <strong>freight courier</strong> options."
+  },
+  "testimonials": [
+    {
+      "quote": "\u201cCordova Courier keeps our Jersey City operations moving.\u201d",
+      "author": "Local Business Owner"
+    },
+    {
+      "quote": "\u201cFast delivery across Jersey City every time.\u201d",
+      "author": "Operations Manager"
+    },
+    {
+      "quote": "\u201cReliable Jersey City courier service we trust for urgent shipments.\u201d",
+      "author": "Logistics Coordinator"
+    }
+  ]
+}

--- a/data/locations/nj/newark.json
+++ b/data/locations/nj/newark.json
@@ -1,0 +1,129 @@
+{
+  "location": {
+    "city": "Newark",
+    "state": "NJ",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Newark and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Newark?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Newark and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in New Jersey?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from New Jersey airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    },
+    {
+      "q": "How fast can you deliver from Newark to nearby cities?",
+      "a": "Most deliveries from Newark to neighboring areas arrive the same day thanks to our dedicated courier network."
+    }
+  ],
+  "hero": {
+    "h1": "Newark, NJ Courier & Delivery Services",
+    "intro": "Fast same-day, freight, and medical deliveries across Newark."
+  },
+  "fastFacts": [
+    {
+      "type": "short",
+      "title": "Service Radius",
+      "content": "50-mile coverage",
+      "seo": "Newark courier delivery radius 50 miles"
+    },
+    {
+      "type": "short",
+      "title": "Availability",
+      "content": "24/7 dispatch",
+      "seo": "Newark 24/7 courier service"
+    },
+    {
+      "type": "long",
+      "title": "Local Expertise",
+      "content": "Newark couriers know the area, using optimal routes for fast <strong>same-day delivery</strong>.",
+      "seo": "Newark same-day delivery courier"
+    },
+    {
+      "type": "long",
+      "title": "Business District",
+      "content": "Central Newark districts enable quick pickups and drop-offs for offices and retail.",
+      "seo": "Newark business courier services"
+    },
+    {
+      "type": "long",
+      "title": "Medical Logistics",
+      "content": "Hospitals and labs in Newark rely on our <strong>medical courier</strong> team for urgent transport.",
+      "seo": "Newark medical courier services"
+    },
+    {
+      "type": "long",
+      "title": "Freight Capacity",
+      "content": "From cargo vans to box trucks, we handle heavy freight in Newark and beyond.",
+      "seo": "Newark freight delivery"
+    }
+  ],
+  "pois": [
+    {
+      "name": "Newark City Hall",
+      "category": "Government",
+      "description": "Regular route stop for document filings and legal <strong>courier service in Newark</strong>."
+    },
+    {
+      "name": "Newark Business District",
+      "category": "Business District",
+      "description": "Dense cluster of offices\u2014ideal for bulk <strong>same-day deliveries</strong> in Newark."
+    },
+    {
+      "name": "Newark Medical Center",
+      "category": "Hospital",
+      "description": "Key destination for <strong>medical courier</strong> runs serving Newark healthcare providers."
+    }
+  ],
+  "coverage": {
+    "county": "Essex County",
+    "description": "Serving all neighborhoods in and around Newark with <strong>same-day</strong> and <strong>freight courier</strong> options."
+  },
+  "testimonials": [
+    {
+      "quote": "\u201cCordova Courier keeps our Newark operations moving.\u201d",
+      "author": "Local Business Owner"
+    },
+    {
+      "quote": "\u201cFast delivery across Newark every time.\u201d",
+      "author": "Operations Manager"
+    },
+    {
+      "quote": "\u201cReliable Newark courier service we trust for urgent shipments.\u201d",
+      "author": "Logistics Coordinator"
+    }
+  ]
+}

--- a/data/locations/nj/trenton.json
+++ b/data/locations/nj/trenton.json
@@ -1,0 +1,129 @@
+{
+  "location": {
+    "city": "Trenton",
+    "state": "NJ",
+    "serviceRadiusMiles": 50
+  },
+  "facts": [
+    {
+      "title": "Company Facts",
+      "items": [
+        "24/7 local courier coverage across Trenton and the greater metro area.",
+        "Airport cargo recovery at local airports with TSA-cleared couriers.",
+        "Employee-first company focused on reliability, safety, and transparency."
+      ]
+    },
+    {
+      "title": "Core Services",
+      "items": [
+        "Same-day delivery for documents, parts, and pallets.",
+        "HIPAA-compliant medical courier for labs, clinics, and hospitals.",
+        "Routed & scheduled delivery programs for recurring stops.",
+        "Last\u2011mile delivery for retailers and e\u2011commerce.",
+        "Expedited statewide and nationwide freight."
+      ]
+    },
+    {
+      "title": "Fleet & Capabilities",
+      "items": [
+        "Sedans, cargo vans, high-roof sprinters, and box trucks.",
+        "Up to 3,300 lbs and ~540 cu ft per high\u2011roof van."
+      ]
+    }
+  ],
+  "faq": [
+    {
+      "q": "Do you deliver outside Trenton?",
+      "a": "Yes. We cover a ~50\u2011mile radius around Trenton and can expedite statewide and nationwide deliveries as needed."
+    },
+    {
+      "q": "Do you handle airport cargo in New Jersey?",
+      "a": "Yes. Our TSA\u2011cleared couriers pick up from New Jersey airports and deliver directly to your dock or site."
+    },
+    {
+      "q": "What are your operating hours?",
+      "a": "We operate 24/7 including weekends and holidays."
+    },
+    {
+      "q": "How fast can you deliver from Trenton to nearby cities?",
+      "a": "Most deliveries from Trenton to neighboring areas arrive the same day thanks to our dedicated courier network."
+    }
+  ],
+  "hero": {
+    "h1": "Trenton, NJ Courier & Delivery Services",
+    "intro": "Fast same-day, freight, and medical deliveries across Trenton."
+  },
+  "fastFacts": [
+    {
+      "type": "short",
+      "title": "Service Radius",
+      "content": "50-mile coverage",
+      "seo": "Trenton courier delivery radius 50 miles"
+    },
+    {
+      "type": "short",
+      "title": "Availability",
+      "content": "24/7 dispatch",
+      "seo": "Trenton 24/7 courier service"
+    },
+    {
+      "type": "long",
+      "title": "Local Expertise",
+      "content": "Trenton couriers know the area, using optimal routes for fast <strong>same-day delivery</strong>.",
+      "seo": "Trenton same-day delivery courier"
+    },
+    {
+      "type": "long",
+      "title": "Business District",
+      "content": "Central Trenton districts enable quick pickups and drop-offs for offices and retail.",
+      "seo": "Trenton business courier services"
+    },
+    {
+      "type": "long",
+      "title": "Medical Logistics",
+      "content": "Hospitals and labs in Trenton rely on our <strong>medical courier</strong> team for urgent transport.",
+      "seo": "Trenton medical courier services"
+    },
+    {
+      "type": "long",
+      "title": "Freight Capacity",
+      "content": "From cargo vans to box trucks, we handle heavy freight in Trenton and beyond.",
+      "seo": "Trenton freight delivery"
+    }
+  ],
+  "pois": [
+    {
+      "name": "Trenton City Hall",
+      "category": "Government",
+      "description": "Regular route stop for document filings and legal <strong>courier service in Trenton</strong>."
+    },
+    {
+      "name": "Trenton Business District",
+      "category": "Business District",
+      "description": "Dense cluster of offices\u2014ideal for bulk <strong>same-day deliveries</strong> in Trenton."
+    },
+    {
+      "name": "Trenton Medical Center",
+      "category": "Hospital",
+      "description": "Key destination for <strong>medical courier</strong> runs serving Trenton healthcare providers."
+    }
+  ],
+  "coverage": {
+    "county": "Mercer County",
+    "description": "Serving all neighborhoods in and around Trenton with <strong>same-day</strong> and <strong>freight courier</strong> options."
+  },
+  "testimonials": [
+    {
+      "quote": "\u201cCordova Courier keeps our Trenton operations moving.\u201d",
+      "author": "Local Business Owner"
+    },
+    {
+      "quote": "\u201cFast delivery across Trenton every time.\u201d",
+      "author": "Operations Manager"
+    },
+    {
+      "quote": "\u201cReliable Trenton courier service we trust for urgent shipments.\u201d",
+      "author": "Logistics Coordinator"
+    }
+  ]
+}

--- a/service-areas/new-jersey/atlantic-city/index.html
+++ b/service-areas/new-jersey/atlantic-city/index.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Atlantic City Courier & Delivery Services | Cordova Courier</title>
+  <meta name="description" content="Fast, professional courier and freight delivery in Atlantic City, New Jersey and surrounding areas." />
+  <link rel="stylesheet" href="/css/master-service.css?v=1.0" />
+  <link rel="stylesheet" href="/css/navbar.css?v=1.0" />
+  <link rel="stylesheet" href="/css/footer.css?v=1.0" />
+  <link href="/images/branding/favicon.ico" rel="icon" type="image/x-icon"/>
+  <link href="/images/branding/favicon-32x32.png" rel="icon" sizes="32x32" type="image/png"/>
+  <link href="/images/branding/favicon-16x16.png" rel="icon" sizes="16x16" type="image/png"/>
+  <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+  <link href="/site.webmanifest" rel="manifest"/>
+  <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
+</head>
+<body>
+<div id="navbar-placeholder"></div>
+<script>
+  fetch('/components/navbar.html')
+    .then(res => res.text())
+    .then(html => {
+      document.getElementById('navbar-placeholder').innerHTML = html;
+      const script = document.createElement('script');
+      script.src = '/js/navbar.js';
+      script.onload = () => {
+        const checkAndRun = () => {
+          const hamburger = document.getElementById('hamburgerBtn');
+          const menu = document.getElementById('mobileMenu');
+          const navbar = document.getElementById('navbar');
+          if (hamburger && menu && navbar && window.setupMobileMenuToggle && window.setupNavbarScrollAndToggle) {
+            window.setupNavbarScrollAndToggle();
+            window.setupMobileMenuToggle();
+          } else {
+            requestAnimationFrame(checkAndRun);
+          }
+        };
+        checkAndRun();
+      };
+      document.body.appendChild(script);
+    });
+</script>
+<div class="hero-section">
+  <nav aria-label="Breadcrumb" class="breadcrumb-nav">
+    <ul class="breadcrumb">
+      <li><a href="/">Home</a></li>
+      <li><a href="/service-areas/">Service Areas</a></li>
+      <li><a href="/service-areas/usa">United States</a></li>
+      <li><a href="/service-areas/new-jersey">New Jersey</a></li>
+      <li>Atlantic City</li>
+    </ul>
+  </nav>
+  <h1>Atlantic City, NJ Courier & Delivery Services</h1>
+  <p>Reliable same-day, freight, and medical deliveries in Atlantic City and across New Jersey.</p>
+  <div class="cta-buttons">
+    <a href="/quote" class="btn">Request a Quote</a>
+  </div>
+</div>
+<section class="services-row">
+  <h2>Our Atlantic City Delivery Solutions</h2>
+  <div class="icons">
+    <div><img src="/images/icons/same-day.svg" alt="Same-Day Delivery"><span>Same-Day</span></div>
+    <div><img src="/images/icons/medical.svg" alt="Medical Courier"><span>Medical</span></div>
+    <div><img src="/images/icons/freight.svg" alt="Freight Delivery"><span>Freight</span></div>
+    <div><img src="/images/icons/airport.svg" alt="Airport Pickup"><span>Airport</span></div>
+    <div><img src="/images/icons/routed.svg" alt="Routed Scheduled Delivery"><span>Routed & Scheduled</span></div>
+    <div><img src="/images/icons/last-mile.svg" alt="Last-Mile Delivery"><span>Last-Mile</span></div>
+    <div><img src="/images/icons/nationwide.svg" alt="Expedited Nationwide Delivery"><span>Expedited Nationwide</span></div>
+  </div>
+</section>
+<section id="reviews" class="grid-section">
+  <h2>Trusted in Atlantic City</h2>
+  <div class="state-grid">
+    <div>
+      <strong>⭐ ⭐ ⭐ ⭐ ⭐</strong><br />
+      “Cordova Courier keeps our Atlantic City operations running smoothly.”<br />
+      <em>– Local Business Owner</em>
+    </div>
+    <div>
+      <strong>⭐ ⭐ ⭐ ⭐ ⭐</strong><br />
+      “Fast deliveries across New Jersey.”<br />
+      <em>– Satisfied Customer</em>
+    </div>
+    <div>
+      <strong>⭐ ⭐ ⭐ ⭐ ⭐</strong><br />
+      “Reliable courier service we trust.”<br />
+      <em>– Logistics Coordinator</em>
+    </div>
+  </div>
+</section>
+<section id="fast-facts" data-city="Atlantic City" data-state="NJ"></section>
+<section id="faq"></section>
+<div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
+<script defer>
+  fetch('/components/footer.html')
+    .then(res => res.text())
+    .then(html => {
+      document.getElementById('footer-placeholder').innerHTML = html;
+    });
+</script>
+</body>
+</html>

--- a/service-areas/new-jersey/index.html
+++ b/service-areas/new-jersey/index.html
@@ -107,10 +107,10 @@
     Cordova Courier proudly serves all of New Jersey's major cities and surrounding areas within a 50-mile radius. We also provide same-day delivery to and from New Jersey airports, businesses, homes, and government offices.
   </p>
   <div class="state-grid">
-    <a href="#">Newark</a>
-    <a href="#">Jersey City</a>
-    <a href="#">Trenton</a>
-    <a href="#">Atlantic City</a>
+    <a href="/service-areas/new-jersey/newark">Newark</a>
+    <a href="/service-areas/new-jersey/jersey-city">Jersey City</a>
+    <a href="/service-areas/new-jersey/trenton">Trenton</a>
+    <a href="/service-areas/new-jersey/atlantic-city">Atlantic City</a>
   </div>
 </section>
 <section id="airports" class="grid-section">

--- a/service-areas/new-jersey/jersey-city/index.html
+++ b/service-areas/new-jersey/jersey-city/index.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Jersey City Courier & Delivery Services | Cordova Courier</title>
+  <meta name="description" content="Fast, professional courier and freight delivery in Jersey City, New Jersey and surrounding areas." />
+  <link rel="stylesheet" href="/css/master-service.css?v=1.0" />
+  <link rel="stylesheet" href="/css/navbar.css?v=1.0" />
+  <link rel="stylesheet" href="/css/footer.css?v=1.0" />
+  <link href="/images/branding/favicon.ico" rel="icon" type="image/x-icon"/>
+  <link href="/images/branding/favicon-32x32.png" rel="icon" sizes="32x32" type="image/png"/>
+  <link href="/images/branding/favicon-16x16.png" rel="icon" sizes="16x16" type="image/png"/>
+  <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+  <link href="/site.webmanifest" rel="manifest"/>
+  <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
+</head>
+<body>
+<div id="navbar-placeholder"></div>
+<script>
+  fetch('/components/navbar.html')
+    .then(res => res.text())
+    .then(html => {
+      document.getElementById('navbar-placeholder').innerHTML = html;
+      const script = document.createElement('script');
+      script.src = '/js/navbar.js';
+      script.onload = () => {
+        const checkAndRun = () => {
+          const hamburger = document.getElementById('hamburgerBtn');
+          const menu = document.getElementById('mobileMenu');
+          const navbar = document.getElementById('navbar');
+          if (hamburger && menu && navbar && window.setupMobileMenuToggle && window.setupNavbarScrollAndToggle) {
+            window.setupNavbarScrollAndToggle();
+            window.setupMobileMenuToggle();
+          } else {
+            requestAnimationFrame(checkAndRun);
+          }
+        };
+        checkAndRun();
+      };
+      document.body.appendChild(script);
+    });
+</script>
+<div class="hero-section">
+  <nav aria-label="Breadcrumb" class="breadcrumb-nav">
+    <ul class="breadcrumb">
+      <li><a href="/">Home</a></li>
+      <li><a href="/service-areas/">Service Areas</a></li>
+      <li><a href="/service-areas/usa">United States</a></li>
+      <li><a href="/service-areas/new-jersey">New Jersey</a></li>
+      <li>Jersey City</li>
+    </ul>
+  </nav>
+  <h1>Jersey City, NJ Courier & Delivery Services</h1>
+  <p>Reliable same-day, freight, and medical deliveries in Jersey City and across New Jersey.</p>
+  <div class="cta-buttons">
+    <a href="/quote" class="btn">Request a Quote</a>
+  </div>
+</div>
+<section class="services-row">
+  <h2>Our Jersey City Delivery Solutions</h2>
+  <div class="icons">
+    <div><img src="/images/icons/same-day.svg" alt="Same-Day Delivery"><span>Same-Day</span></div>
+    <div><img src="/images/icons/medical.svg" alt="Medical Courier"><span>Medical</span></div>
+    <div><img src="/images/icons/freight.svg" alt="Freight Delivery"><span>Freight</span></div>
+    <div><img src="/images/icons/airport.svg" alt="Airport Pickup"><span>Airport</span></div>
+    <div><img src="/images/icons/routed.svg" alt="Routed Scheduled Delivery"><span>Routed & Scheduled</span></div>
+    <div><img src="/images/icons/last-mile.svg" alt="Last-Mile Delivery"><span>Last-Mile</span></div>
+    <div><img src="/images/icons/nationwide.svg" alt="Expedited Nationwide Delivery"><span>Expedited Nationwide</span></div>
+  </div>
+</section>
+<section id="reviews" class="grid-section">
+  <h2>Trusted in Jersey City</h2>
+  <div class="state-grid">
+    <div>
+      <strong>⭐ ⭐ ⭐ ⭐ ⭐</strong><br />
+      “Cordova Courier keeps our Jersey City operations running smoothly.”<br />
+      <em>– Local Business Owner</em>
+    </div>
+    <div>
+      <strong>⭐ ⭐ ⭐ ⭐ ⭐</strong><br />
+      “Fast deliveries across New Jersey.”<br />
+      <em>– Satisfied Customer</em>
+    </div>
+    <div>
+      <strong>⭐ ⭐ ⭐ ⭐ ⭐</strong><br />
+      “Reliable courier service we trust.”<br />
+      <em>– Logistics Coordinator</em>
+    </div>
+  </div>
+</section>
+<section id="fast-facts" data-city="Jersey City" data-state="NJ"></section>
+<section id="faq"></section>
+<div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
+<script defer>
+  fetch('/components/footer.html')
+    .then(res => res.text())
+    .then(html => {
+      document.getElementById('footer-placeholder').innerHTML = html;
+    });
+</script>
+</body>
+</html>

--- a/service-areas/new-jersey/newark/index.html
+++ b/service-areas/new-jersey/newark/index.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Newark Courier & Delivery Services | Cordova Courier</title>
+  <meta name="description" content="Fast, professional courier and freight delivery in Newark, New Jersey and surrounding areas." />
+  <link rel="stylesheet" href="/css/master-service.css?v=1.0" />
+  <link rel="stylesheet" href="/css/navbar.css?v=1.0" />
+  <link rel="stylesheet" href="/css/footer.css?v=1.0" />
+  <link href="/images/branding/favicon.ico" rel="icon" type="image/x-icon"/>
+  <link href="/images/branding/favicon-32x32.png" rel="icon" sizes="32x32" type="image/png"/>
+  <link href="/images/branding/favicon-16x16.png" rel="icon" sizes="16x16" type="image/png"/>
+  <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+  <link href="/site.webmanifest" rel="manifest"/>
+  <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
+</head>
+<body>
+<div id="navbar-placeholder"></div>
+<script>
+  fetch('/components/navbar.html')
+    .then(res => res.text())
+    .then(html => {
+      document.getElementById('navbar-placeholder').innerHTML = html;
+      const script = document.createElement('script');
+      script.src = '/js/navbar.js';
+      script.onload = () => {
+        const checkAndRun = () => {
+          const hamburger = document.getElementById('hamburgerBtn');
+          const menu = document.getElementById('mobileMenu');
+          const navbar = document.getElementById('navbar');
+          if (hamburger && menu && navbar && window.setupMobileMenuToggle && window.setupNavbarScrollAndToggle) {
+            window.setupNavbarScrollAndToggle();
+            window.setupMobileMenuToggle();
+          } else {
+            requestAnimationFrame(checkAndRun);
+          }
+        };
+        checkAndRun();
+      };
+      document.body.appendChild(script);
+    });
+</script>
+<div class="hero-section">
+  <nav aria-label="Breadcrumb" class="breadcrumb-nav">
+    <ul class="breadcrumb">
+      <li><a href="/">Home</a></li>
+      <li><a href="/service-areas/">Service Areas</a></li>
+      <li><a href="/service-areas/usa">United States</a></li>
+      <li><a href="/service-areas/new-jersey">New Jersey</a></li>
+      <li>Newark</li>
+    </ul>
+  </nav>
+  <h1>Newark, NJ Courier & Delivery Services</h1>
+  <p>Reliable same-day, freight, and medical deliveries in Newark and across New Jersey.</p>
+  <div class="cta-buttons">
+    <a href="/quote" class="btn">Request a Quote</a>
+  </div>
+</div>
+<section class="services-row">
+  <h2>Our Newark Delivery Solutions</h2>
+  <div class="icons">
+    <div><img src="/images/icons/same-day.svg" alt="Same-Day Delivery"><span>Same-Day</span></div>
+    <div><img src="/images/icons/medical.svg" alt="Medical Courier"><span>Medical</span></div>
+    <div><img src="/images/icons/freight.svg" alt="Freight Delivery"><span>Freight</span></div>
+    <div><img src="/images/icons/airport.svg" alt="Airport Pickup"><span>Airport</span></div>
+    <div><img src="/images/icons/routed.svg" alt="Routed Scheduled Delivery"><span>Routed & Scheduled</span></div>
+    <div><img src="/images/icons/last-mile.svg" alt="Last-Mile Delivery"><span>Last-Mile</span></div>
+    <div><img src="/images/icons/nationwide.svg" alt="Expedited Nationwide Delivery"><span>Expedited Nationwide</span></div>
+  </div>
+</section>
+<section id="reviews" class="grid-section">
+  <h2>Trusted in Newark</h2>
+  <div class="state-grid">
+    <div>
+      <strong>⭐ ⭐ ⭐ ⭐ ⭐</strong><br />
+      “Cordova Courier keeps our Newark operations running smoothly.”<br />
+      <em>– Local Business Owner</em>
+    </div>
+    <div>
+      <strong>⭐ ⭐ ⭐ ⭐ ⭐</strong><br />
+      “Fast deliveries across New Jersey.”<br />
+      <em>– Satisfied Customer</em>
+    </div>
+    <div>
+      <strong>⭐ ⭐ ⭐ ⭐ ⭐</strong><br />
+      “Reliable courier service we trust.”<br />
+      <em>– Logistics Coordinator</em>
+    </div>
+  </div>
+</section>
+<section id="fast-facts" data-city="Newark" data-state="NJ"></section>
+<section id="faq"></section>
+<div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
+<script defer>
+  fetch('/components/footer.html')
+    .then(res => res.text())
+    .then(html => {
+      document.getElementById('footer-placeholder').innerHTML = html;
+    });
+</script>
+</body>
+</html>

--- a/service-areas/new-jersey/trenton/index.html
+++ b/service-areas/new-jersey/trenton/index.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Trenton Courier & Delivery Services | Cordova Courier</title>
+  <meta name="description" content="Fast, professional courier and freight delivery in Trenton, New Jersey and surrounding areas." />
+  <link rel="stylesheet" href="/css/master-service.css?v=1.0" />
+  <link rel="stylesheet" href="/css/navbar.css?v=1.0" />
+  <link rel="stylesheet" href="/css/footer.css?v=1.0" />
+  <link href="/images/branding/favicon.ico" rel="icon" type="image/x-icon"/>
+  <link href="/images/branding/favicon-32x32.png" rel="icon" sizes="32x32" type="image/png"/>
+  <link href="/images/branding/favicon-16x16.png" rel="icon" sizes="16x16" type="image/png"/>
+  <link href="/images/branding/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+  <link href="/site.webmanifest" rel="manifest"/>
+  <meta content="#ffffff" name="theme-color"/>
+  <link rel="stylesheet" href="/css/accordion.css">
+</head>
+<body>
+<div id="navbar-placeholder"></div>
+<script>
+  fetch('/components/navbar.html')
+    .then(res => res.text())
+    .then(html => {
+      document.getElementById('navbar-placeholder').innerHTML = html;
+      const script = document.createElement('script');
+      script.src = '/js/navbar.js';
+      script.onload = () => {
+        const checkAndRun = () => {
+          const hamburger = document.getElementById('hamburgerBtn');
+          const menu = document.getElementById('mobileMenu');
+          const navbar = document.getElementById('navbar');
+          if (hamburger && menu && navbar && window.setupMobileMenuToggle && window.setupNavbarScrollAndToggle) {
+            window.setupNavbarScrollAndToggle();
+            window.setupMobileMenuToggle();
+          } else {
+            requestAnimationFrame(checkAndRun);
+          }
+        };
+        checkAndRun();
+      };
+      document.body.appendChild(script);
+    });
+</script>
+<div class="hero-section">
+  <nav aria-label="Breadcrumb" class="breadcrumb-nav">
+    <ul class="breadcrumb">
+      <li><a href="/">Home</a></li>
+      <li><a href="/service-areas/">Service Areas</a></li>
+      <li><a href="/service-areas/usa">United States</a></li>
+      <li><a href="/service-areas/new-jersey">New Jersey</a></li>
+      <li>Trenton</li>
+    </ul>
+  </nav>
+  <h1>Trenton, NJ Courier & Delivery Services</h1>
+  <p>Reliable same-day, freight, and medical deliveries in Trenton and across New Jersey.</p>
+  <div class="cta-buttons">
+    <a href="/quote" class="btn">Request a Quote</a>
+  </div>
+</div>
+<section class="services-row">
+  <h2>Our Trenton Delivery Solutions</h2>
+  <div class="icons">
+    <div><img src="/images/icons/same-day.svg" alt="Same-Day Delivery"><span>Same-Day</span></div>
+    <div><img src="/images/icons/medical.svg" alt="Medical Courier"><span>Medical</span></div>
+    <div><img src="/images/icons/freight.svg" alt="Freight Delivery"><span>Freight</span></div>
+    <div><img src="/images/icons/airport.svg" alt="Airport Pickup"><span>Airport</span></div>
+    <div><img src="/images/icons/routed.svg" alt="Routed Scheduled Delivery"><span>Routed & Scheduled</span></div>
+    <div><img src="/images/icons/last-mile.svg" alt="Last-Mile Delivery"><span>Last-Mile</span></div>
+    <div><img src="/images/icons/nationwide.svg" alt="Expedited Nationwide Delivery"><span>Expedited Nationwide</span></div>
+  </div>
+</section>
+<section id="reviews" class="grid-section">
+  <h2>Trusted in Trenton</h2>
+  <div class="state-grid">
+    <div>
+      <strong>⭐ ⭐ ⭐ ⭐ ⭐</strong><br />
+      “Cordova Courier keeps our Trenton operations running smoothly.”<br />
+      <em>– Local Business Owner</em>
+    </div>
+    <div>
+      <strong>⭐ ⭐ ⭐ ⭐ ⭐</strong><br />
+      “Fast deliveries across New Jersey.”<br />
+      <em>– Satisfied Customer</em>
+    </div>
+    <div>
+      <strong>⭐ ⭐ ⭐ ⭐ ⭐</strong><br />
+      “Reliable courier service we trust.”<br />
+      <em>– Logistics Coordinator</em>
+    </div>
+  </div>
+</section>
+<section id="fast-facts" data-city="Trenton" data-state="NJ"></section>
+<section id="faq"></section>
+<div id="footer-placeholder"></div>
+<script defer src="/js/accordion.js"></script>
+<script defer>
+  fetch('/components/footer.html')
+    .then(res => res.text())
+    .then(html => {
+      document.getElementById('footer-placeholder').innerHTML = html;
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add city landing pages for Newark, Jersey City, Trenton, and Atlantic City
- wire New Jersey service area page to new city pages
- supply location data for each city to power fast facts and FAQs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689586b6719c832c96e1498f8a21fcb9